### PR TITLE
Fix closes #322, patches gui de-syncing and fixes #247

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,2 +1,6 @@
-+Added a Config Option to allow Tour Rail blocks to be disabled
-*Fixed Action Figures not displaying the correct pose
+*Fixed desyncing process bars for all machines
+*Fixed desyncing items when taken out of the output slots
+*Fixed client-side dublication bug with cleaning station
+*Fixed output slots accepting items from the player which isn't possible anymore
+*Fixed the feeders's default input slot -> Now upper left corner
+*Fixed a problem with herds losing their leader which crashed the game

--- a/src/main/java/org/jurassicraft/client/gui/CleaningStationGui.java
+++ b/src/main/java/org/jurassicraft/client/gui/CleaningStationGui.java
@@ -4,6 +4,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -18,7 +19,7 @@ public class CleaningStationGui extends GuiContainer {
     private IInventory inventory;
 
     public CleaningStationGui(InventoryPlayer playerInv, IInventory inventory) {
-        super(new CleaningStationContainer(playerInv, inventory));
+        super(new CleaningStationContainer(playerInv, (TileEntity) inventory));
         this.playerInventory = playerInv;
         this.inventory = inventory;
     }

--- a/src/main/java/org/jurassicraft/server/block/entity/CleaningStationBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/CleaningStationBlockEntity.java
@@ -183,13 +183,14 @@ public class CleaningStationBlockEntity extends TileEntityLockable implements IT
     public void update() {
         boolean isCleaning = this.isCleaning();
         boolean dirty = false;
-
+        
+        if(!world.isRemote) {
         if (this.isCleaning() && this.canClean()) {
             --this.cleaningStationWaterTime;
             dirty = true;
         }
+     
 
-        if (!this.world.isRemote) {
             if (!this.isCleaning() && (this.slots.get(1).isEmpty() || this.slots.get(0).isEmpty())) {
                 if (!this.isCleaning() && this.cleanTime > 0) {
                     this.cleanTime = MathHelper.clamp(this.cleanTime - 2, 0, this.totalCleanTime);
@@ -230,15 +231,15 @@ public class CleaningStationBlockEntity extends TileEntityLockable implements IT
             if (isCleaning != this.isCleaning()) {
                 dirty = true;
             }
-        }
-
+        
+    
         if (this.cleaningStationWaterTime == 0) {
             this.cleanTime = 0;
         }
-
-        if (dirty) {
+        
+        }
+        if (dirty && !world.isRemote) {
             this.markDirty();
-            this.world.notifyBlockUpdate(this.pos, this.world.getBlockState(this.pos), this.world.getBlockState(this.pos), 3);
         }
     }
 
@@ -391,6 +392,11 @@ public class CleaningStationBlockEntity extends TileEntityLockable implements IT
     @Override
     public SPacketUpdateTileEntity getUpdatePacket() {
         return new SPacketUpdateTileEntity(this.pos, 0, this.writeToNBT(new NBTTagCompound()));
+    }
+    
+    @Override
+    public NBTTagCompound getUpdateTag() {
+        return this.writeToNBT(new NBTTagCompound());
     }
 
     @Override

--- a/src/main/java/org/jurassicraft/server/block/entity/MachineBaseBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/MachineBaseBlockEntity.java
@@ -178,8 +178,9 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
 
     @Override
     public void update() {
+    	
         NonNullList<ItemStack> slots = this.getSlots();
-
+     
         for (int process = 0; process < this.getProcessCount(); process++) {
             boolean flag = this.isProcessing(process);
             boolean dirty = false;
@@ -207,8 +208,12 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
                         }
                     }
                     this.totalProcessTime[process] = total;
+                    if (!this.world.isRemote)
+                    {
                     this.processItem(process);
                     this.onSlotUpdate();
+                    }
+                  
                 }
 
                 dirty = true;
@@ -231,6 +236,7 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
             }
         }
     }
+    	
 
     @Override
     public boolean isUsableByPlayer(EntityPlayer player) {
@@ -332,7 +338,7 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
 
     @Override
     public int getFieldCount() {
-        return this.getProcessCount() * 2;
+        return this.getProcessCount();
     }
 
     @Override

--- a/src/main/java/org/jurassicraft/server/block/entity/MachineBaseBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/MachineBaseBlockEntity.java
@@ -20,7 +20,6 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
-
 import javax.annotation.Nullable;
 
 public abstract  class MachineBaseBlockEntity extends TileEntityLockable implements ITickable, ISidedInventory {
@@ -180,7 +179,7 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
     public void update() {
     	
         NonNullList<ItemStack> slots = this.getSlots();
-     
+        if(!world.isRemote) {
         for (int process = 0; process < this.getProcessCount(); process++) {
             boolean flag = this.isProcessing(process);
             boolean dirty = false;
@@ -234,6 +233,7 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
             if (dirty && !this.world.isRemote) {
                 this.markDirty();
             }
+        }
         }
     }
     	

--- a/src/main/java/org/jurassicraft/server/block/entity/MachineBaseBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/MachineBaseBlockEntity.java
@@ -338,7 +338,7 @@ public abstract  class MachineBaseBlockEntity extends TileEntityLockable impleme
 
     @Override
     public int getFieldCount() {
-        return this.getProcessCount();
+        return this.getProcessCount() * 2;
     }
 
     @Override

--- a/src/main/java/org/jurassicraft/server/container/CleaningStationContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/CleaningStationContainer.java
@@ -5,24 +5,28 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
+import net.minecraft.tileentity.TileEntity;
+
+import org.jurassicraft.server.block.entity.CleaningStationBlockEntity;
 import org.jurassicraft.server.container.slot.CleanableItemSlot;
+import org.jurassicraft.server.container.slot.CustomSlot;
 import org.jurassicraft.server.container.slot.FossilSlot;
 import org.jurassicraft.server.container.slot.WaterBucketSlot;
 
 public class CleaningStationContainer extends MachineContainer {
-    private final IInventory tileCleaningStation;
+    private final CleaningStationBlockEntity tileCleaningStation;
 
-    public CleaningStationContainer(InventoryPlayer invPlayer, IInventory cleaningStation) {
-        super(cleaningStation);
-        this.tileCleaningStation = cleaningStation;
-        this.addSlotToContainer(new CleanableItemSlot(cleaningStation, 0, 56, 17));
-        this.addSlotToContainer(new WaterBucketSlot(cleaningStation, 1, 56, 53));
+    public CleaningStationContainer(InventoryPlayer invPlayer, TileEntity tileEntity) {
+        super((IInventory) tileEntity);
+        this.tileCleaningStation = (CleaningStationBlockEntity) tileEntity;
+        this.addSlotToContainer(new CleanableItemSlot(tileCleaningStation, 0, 56, 17));
+        this.addSlotToContainer(new WaterBucketSlot(tileCleaningStation, 1, 56, 53));
 
         int i;
 
         for (i = 0; i < 3; i++) {
             for (int j = 0; j < 2; j++) {
-                this.addSlotToContainer(new FossilSlot(cleaningStation, i + (j * 3) + 2, i * 18 + 93 + 15, j * 18 + 26));
+                this.addSlotToContainer(new CustomSlot(tileCleaningStation, i + (j * 3) + 2, i * 18 + 93 + 15, j * 18 + 26, stack -> false));
             }
         }
 
@@ -36,9 +40,9 @@ public class CleaningStationContainer extends MachineContainer {
             this.addSlotToContainer(new Slot(invPlayer, i, 8 + i * 18, 142));
         }
     }
-
-    @Override
-    public void addListener(IContainerListener listener) {
+    
+    public void addListener(IContainerListener listener)
+    {
         super.addListener(listener);
         listener.sendAllWindowProperties(this, this.tileCleaningStation);
     }

--- a/src/main/java/org/jurassicraft/server/container/CultivateContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/CultivateContainer.java
@@ -7,6 +7,7 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.tileentity.TileEntity;
 import org.jurassicraft.server.block.entity.CultivatorBlockEntity;
 import org.jurassicraft.server.container.slot.CultivatorSyringeSlot;
+import org.jurassicraft.server.container.slot.CustomSlot;
 import org.jurassicraft.server.container.slot.NutrientSlot;
 import org.jurassicraft.server.container.slot.OutputSlot;
 import org.jurassicraft.server.container.slot.WaterBucketSlot;
@@ -20,7 +21,7 @@ public class CultivateContainer extends MachineContainer {
         this.addSlotToContainer(new CultivatorSyringeSlot(this.cultivator, 0, 122, 44));
         this.addSlotToContainer(new NutrientSlot(this.cultivator, 1, 208, 20));
         this.addSlotToContainer(new WaterBucketSlot(this.cultivator, 2, 12, 20));
-        this.addSlotToContainer(new OutputSlot(this.cultivator, 3, 12, 68));
+        this.addSlotToContainer(new CustomSlot(this.cultivator, 3, 12, 68, stack -> false));
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 9; ++j) {

--- a/src/main/java/org/jurassicraft/server/container/DNACombinatorHybridizerContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/DNACombinatorHybridizerContainer.java
@@ -6,6 +6,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.tileentity.TileEntity;
 import org.jurassicraft.server.block.entity.DNACombinatorHybridizerBlockEntity;
+import org.jurassicraft.server.container.slot.CustomSlot;
 import org.jurassicraft.server.container.slot.StorageSlot;
 
 public class DNACombinatorHybridizerContainer extends MachineContainer {
@@ -32,11 +33,11 @@ public class DNACombinatorHybridizerContainer extends MachineContainer {
             this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 5, 110, 17, true));
             this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 6, 130, 17, true));
             this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 7, 150, 17, true));
-            this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 10, 80, 56, true));
+            this.addSlotToContainer(new CustomSlot(this.dnaHybridizer, 10, 80, 56, stack -> false));
         } else {
             this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 8, 55, 13, true));
             this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 9, 105, 13, true));
-            this.addSlotToContainer(new StorageSlot(this.dnaHybridizer, 11, 81, 60, true));
+            this.addSlotToContainer(new CustomSlot(this.dnaHybridizer, 11, 81, 60, stack -> false));
         }
 
         int i;

--- a/src/main/java/org/jurassicraft/server/container/DNAExtractorContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/DNAExtractorContainer.java
@@ -6,6 +6,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.tileentity.TileEntity;
 import org.jurassicraft.server.block.entity.DNAExtractorBlockEntity;
+import org.jurassicraft.server.container.slot.CustomSlot;
 import org.jurassicraft.server.container.slot.DNAExtractionSlot;
 import org.jurassicraft.server.container.slot.StorageSlot;
 
@@ -17,10 +18,10 @@ public class DNAExtractorContainer extends MachineContainer {
         this.extractor = (DNAExtractorBlockEntity) tileEntity;
         this.addSlotToContainer(new StorageSlot(this.extractor, 1, 55, 47, false));
         this.addSlotToContainer(new DNAExtractionSlot(this.extractor, 0, 55, 26));
-        this.addSlotToContainer(new StorageSlot(this.extractor, 2, 108, 28, true));
-        this.addSlotToContainer(new StorageSlot(this.extractor, 3, 126, 28, true));
-        this.addSlotToContainer(new StorageSlot(this.extractor, 4, 108, 46, true));
-        this.addSlotToContainer(new StorageSlot(this.extractor, 5, 126, 46, true));
+        this.addSlotToContainer(new CustomSlot(this.extractor, 2, 108, 28, stack -> false));
+        this.addSlotToContainer(new CustomSlot(this.extractor, 3, 126, 28, stack -> false));
+        this.addSlotToContainer(new CustomSlot(this.extractor, 4, 108, 46, stack -> false));
+        this.addSlotToContainer(new CustomSlot(this.extractor, 5, 126, 46, stack -> false));
 
         int i;
 

--- a/src/main/java/org/jurassicraft/server/container/DNASequencerContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/DNASequencerContainer.java
@@ -6,6 +6,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.tileentity.TileEntity;
 import org.jurassicraft.server.block.entity.DNASequencerBlockEntity;
+import org.jurassicraft.server.container.slot.CustomSlot;
 import org.jurassicraft.server.container.slot.SequencableItemSlot;
 import org.jurassicraft.server.container.slot.StorageSlot;
 
@@ -24,9 +25,9 @@ public class DNASequencerContainer extends MachineContainer {
         this.addSlotToContainer(new SequencableItemSlot(this.dnaSequencer, 4, 44, 56));
         this.addSlotToContainer(new StorageSlot(this.dnaSequencer, 5, 66, 56, false, 1));
 
-        this.addSlotToContainer(new StorageSlot(this.dnaSequencer, 6, 113, 16, true, 1));
-        this.addSlotToContainer(new StorageSlot(this.dnaSequencer, 7, 113, 36, true, 1));
-        this.addSlotToContainer(new StorageSlot(this.dnaSequencer, 8, 113, 56, true, 1));
+        this.addSlotToContainer(new CustomSlot(this.dnaSequencer, 6, 113, 16, stack -> false, 1));
+        this.addSlotToContainer(new CustomSlot(this.dnaSequencer, 7, 113, 36, stack -> false, 1));
+        this.addSlotToContainer(new CustomSlot(this.dnaSequencer, 8, 113, 56, stack -> false, 1));
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 9; ++j) {

--- a/src/main/java/org/jurassicraft/server/container/DNASynthesizerContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/DNASynthesizerContainer.java
@@ -25,7 +25,7 @@ public class DNASynthesizerContainer extends MachineContainer {
 
         for (i = 0; i < 2; i++) {
             for (int j = 0; j < 2; j++) {
-                this.addSlotToContainer(new Slot(this.dnaSynthesizer, i + (j * 2) + 3, i * 18 + 119, j * 18 + 26));
+                this.addSlotToContainer(new CustomSlot(this.dnaSynthesizer, i + (j * 2) + 3, i * 18 + 119, j * 18 + 26, stack -> false));
             }
         }
 

--- a/src/main/java/org/jurassicraft/server/container/EmbryoCalcificationMachineContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/EmbryoCalcificationMachineContainer.java
@@ -21,7 +21,7 @@ public class EmbryoCalcificationMachineContainer extends MachineContainer {
         this.addSlotToContainer(new SyringeSlot(this.calcificationMachine, 0, 34, 14));
         this.addSlotToContainer(new CustomSlot(this.calcificationMachine, 1, 34, 50, stack -> stack.getItem() == Items.EGG));
 
-        this.addSlotToContainer(new Slot(this.calcificationMachine, 2, 97, 32));
+        this.addSlotToContainer(new CustomSlot(this.calcificationMachine, 2, 97, 32, stack -> false));
 
         for (int i = 0; i < 3; ++i) {
             for (int j = 0; j < 9; ++j) {

--- a/src/main/java/org/jurassicraft/server/container/EmbryonicMachineContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/EmbryonicMachineContainer.java
@@ -26,7 +26,7 @@ public class EmbryonicMachineContainer extends MachineContainer {
 
         for (i = 0; i < 2; i++) {
             for (int j = 0; j < 2; j++) {
-                this.addSlotToContainer(new Slot(this.embryonicMachine, i + (j * 2) + 3, i * 18 + 119, j * 18 + 26));
+                this.addSlotToContainer(new CustomSlot(this.embryonicMachine, i + (j * 2) + 3, i * 18 + 119, j * 18 + 26, stack -> false));
             }
         }
 

--- a/src/main/java/org/jurassicraft/server/container/FeederContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/FeederContainer.java
@@ -16,35 +16,29 @@ public class FeederContainer extends MachineContainer {
 
         this.tile = tile;
 
-        int id = 0;
-
-        for (int x = 0; x < 9; x++) {
-            this.addSlotToContainer(new Slot(inventory, id, 8 + x * 18, 142));
-            id++;
-        }
-
-        for (int y = 0; y < 3; y++) {
-            for (int x = 0; x < 9; x++) {
-                this.addSlotToContainer(new Slot(inventory, id, 8 + x * 18, 84 + y * 18));
-                id++;
+        for (int row = 0; row < 3; row++) {
+            for (int column = 0; column < 3; column++) {
+                this.addSlotToContainer(new CustomSlot(tile, row + (column * 3), 26 + row * 18, 18 + column * 18, stack -> FoodHelper.isFoodType(stack.getItem(), FoodType.MEAT) || FoodHelper.isFoodType(stack.getItem(), FoodType.FISH)));
             }
         }
 
-        id = 0;
-
-        for (int x = 0; x < 3; x++) {
-            for (int y = 0; y < 3; y++) {
-                this.addSlotToContainer(new CustomSlot(tile, id, 26 + x * 18, 18 + y * 18, stack -> FoodHelper.isFoodType(stack.getItem(), FoodType.MEAT) || FoodHelper.isFoodType(stack.getItem(), FoodType.FISH)));
-                id++;
+        for (int row = 0; row < 3; row++) {
+            for (int column = 0; column < 3; column++) {
+                this.addSlotToContainer(new CustomSlot(tile, row + (column * 3) + 9, 98 + row * 18, 18 + column * 18, stack -> FoodHelper.isFoodType(stack.getItem(), FoodType.PLANT)));
+            }
+        }
+        
+        for (int row = 0; row < 3; ++row) {
+            for (int column = 0; column < 9; ++column) {
+                this.addSlotToContainer(new Slot(inventory, column + row * 9 + 9, 8 + column * 18, 84 + row * 18));
             }
         }
 
-        for (int x = 0; x < 3; x++) {
-            for (int y = 0; y < 3; y++) {
-                this.addSlotToContainer(new CustomSlot(tile, id, 98 + x * 18, 18 + y * 18, stack -> FoodHelper.isFoodType(stack.getItem(), FoodType.PLANT)));
-                id++;
-            }
+        for (int column = 0; column < 9; ++column) {
+            this.addSlotToContainer(new Slot(inventory, column, 8 + column * 18, 142));
         }
+        
+        
     }
 
     @Override

--- a/src/main/java/org/jurassicraft/server/container/MachineContainer.java
+++ b/src/main/java/org/jurassicraft/server/container/MachineContainer.java
@@ -2,6 +2,7 @@ package org.jurassicraft.server.container;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
@@ -16,9 +17,7 @@ public abstract class MachineContainer extends Container {
         this.inventory = inventory;
         this.fields = new int[inventory.getFieldCount()];
     }
-
-    //TODO Crashing
-    /*
+    
     @Override
     public void detectAndSendChanges() {
         super.detectAndSendChanges();
@@ -37,7 +36,7 @@ public abstract class MachineContainer extends Container {
             this.fields[fieldIndex] = this.inventory.getField(fieldIndex);
         }
     }
-    */
+    
 
     @Override
     @SideOnly(Side.CLIENT)

--- a/src/main/java/org/jurassicraft/server/container/slot/CustomSlot.java
+++ b/src/main/java/org/jurassicraft/server/container/slot/CustomSlot.java
@@ -8,14 +8,25 @@ import java.util.function.Predicate;
 
 public class CustomSlot extends Slot {
     private Predicate<ItemStack> item;
+    private final int stackLimit;
 
     public CustomSlot(IInventory inventory, int slotIndex, int xPosition, int yPosition, Predicate<ItemStack> item) {
+        this(inventory, slotIndex, xPosition, yPosition, item, 64);
+    }
+    
+    public CustomSlot(IInventory inventory, int slotIndex, int xPosition, int yPosition, Predicate<ItemStack> item, int stackLimit) {
         super(inventory, slotIndex, xPosition, yPosition);
         this.item = item;
+        this.stackLimit = stackLimit;
     }
 
     @Override
     public boolean isItemValid(ItemStack stack) {
         return this.item.test(stack);
+    }
+    
+    @Override
+    public int getSlotStackLimit() {
+        return stackLimit;
     }
 }

--- a/src/main/java/org/jurassicraft/server/container/slot/StorageSlot.java
+++ b/src/main/java/org/jurassicraft/server/container/slot/StorageSlot.java
@@ -28,4 +28,9 @@ public class StorageSlot extends Slot {
             return stack.getItem() == ItemHandler.STORAGE_DISC && (stack.getTagCompound() == null || !stack.getTagCompound().hasKey("DNAQuality"));
         }
     }
+    
+    @Override
+    public int getSlotStackLimit() {
+    	return stackLimit;
+    }
 }

--- a/src/main/java/org/jurassicraft/server/entity/ai/Herd.java
+++ b/src/main/java/org/jurassicraft/server/entity/ai/Herd.java
@@ -272,7 +272,7 @@ public class Herd implements Iterable<DinosaurEntity> {
                     Herd otherHerd = entity.herd;
                     if (otherHerd == null || otherHerd.members.size() == 1) {
                         if (this.size() >= this.herdType.getMaxHerdSize()) {
-                            if (GameRuleHandler.KILL_HERD_OUTCAST.getBoolean(this.leader.world) && this.herdType.getDinosaurType() == Dinosaur.DinosaurType.AGGRESSIVE && !this.enemies.contains(entity)) {
+                            if (this.leader != null && GameRuleHandler.KILL_HERD_OUTCAST.getBoolean(this.leader.world) && this.herdType.getDinosaurType() == Dinosaur.DinosaurType.AGGRESSIVE && !this.enemies.contains(entity)) {
                                 this.enemies.add(entity);
                             }
                             return;


### PR DESCRIPTION
**#322 Herding**:
Re-Instancing the herds and splitting herds sometimes cause the leader
value to be NULL, which causes the NullPointerException. This simple check prevents from crashing the game until a new leader has been defined.

**De-syncing**:
The mod didn't separate client- and serverside correctly which caused
this bug for the grinder.

**#247 Feeder**:
The feeder's default slot is now set to Top Left, not to Bottom Right.