### PR TITLE
Fixed #392 by shortening IDs

### DIFF
--- a/src/main/java/org/jurassicraft/server/block/entity/DNACombinatorHybridizerBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/DNACombinatorHybridizerBlockEntity.java
@@ -222,7 +222,7 @@ public class DNACombinatorHybridizerBlockEntity extends MachineBaseBlockEntity {
 
     @Override
     public String getGuiID() {
-        return JurassiCraft.MODID + ":dna_combinator_hybridizer";
+    	return JurassiCraft.MODID + ":dna_comb_hybrid";
     }
 
     @Override

--- a/src/main/java/org/jurassicraft/server/block/entity/EmbryoCalcificationMachineBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/EmbryoCalcificationMachineBlockEntity.java
@@ -103,7 +103,7 @@ public class EmbryoCalcificationMachineBlockEntity extends MachineBaseBlockEntit
 
     @Override
     public String getGuiID() {
-        return JurassiCraft.MODID + ":embryo_calcification_machine";
+    	return JurassiCraft.MODID + ":em_calcification_m";
     }
 
     @Override

--- a/src/main/java/org/jurassicraft/server/block/entity/FeederBlockEntity.java
+++ b/src/main/java/org/jurassicraft/server/block/entity/FeederBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.util.SoundCategory;
 import org.jurassicraft.JurassiCraft;
 import org.jurassicraft.client.sound.SoundHandler;
 import org.jurassicraft.server.block.machine.FeederBlock;
+import org.jurassicraft.server.container.FeederContainer;
 import org.jurassicraft.server.entity.DinosaurEntity;
 import org.jurassicraft.server.food.FoodHelper;
 
@@ -36,7 +37,7 @@ public class FeederBlockEntity extends TileEntityLockable implements ITickable, 
 
     @Override
     public Container createContainer(InventoryPlayer inventory, EntityPlayer player) {
-        return null;
+        return new FeederContainer(inventory, this);
     }
 
     @Override


### PR DESCRIPTION
- The spectator description packets only allow gui-IDs with a maximum of 32 characters