### PR TITLE
Fixed #442

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
-*Fixed the dinosaur's order gui
-*The helicopter is now capable of flying on multiplayer servers
-*Fixed color rendering on tour rails
+*Fixed that spawning action figures of a certain gender didn't work on servers
+*Fixed that dinosaurs weren't rendered correctly in mob spawners
+*Fixed that decayable JC leaves are loosing that property after some time
+*Fixed a rare crash problem with the dart gun

--- a/src/main/java/org/jurassicraft/server/entity/TranquilizerDartEntity.java
+++ b/src/main/java/org/jurassicraft/server/entity/TranquilizerDartEntity.java
@@ -69,12 +69,14 @@ public class TranquilizerDartEntity extends EntityThrowable implements IEntityAd
 
     @Override
     public void writeSpawnData(ByteBuf buffer) {
-	ByteBufUtils.writeItemStack(buffer, stack);
+	if(stack != null)
+		ByteBufUtils.writeItemStack(buffer, stack);
     }
 
     @Override
     public void readSpawnData(ByteBuf additionalData) {
-	stack = ByteBufUtils.readItemStack(additionalData);
+	if(stack != null)
+		stack = ByteBufUtils.readItemStack(additionalData);
     }
     
 }


### PR DESCRIPTION
- The projectile's entity lacks the stack object after re-entering a world. As we don't want to write the stack into it's NBT this prevents the entity to crash the game in that specific case.