### PR TITLE
My PR Request : Renewable Peat

### DIFF
--- a/src/main/java/org/jurassicraft/server/block/PeatBlock.java
+++ b/src/main/java/org/jurassicraft/server/block/PeatBlock.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeSwamp;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.jurassicraft.server.conf.JurassiCraftConfig;
 import org.jurassicraft.server.plugin.jei.category.moss.PeatItem;
 import org.jurassicraft.server.tab.TabHandler;
 
@@ -22,6 +23,7 @@ import java.util.Random;
 
 public class PeatBlock extends Block implements PeatItem {
     public static final PropertyInteger MOISTURE = PropertyInteger.create("moisture", 0, 7);
+    public int peatGenerationSpeed = JurassiCraftConfig.PLANT_GENERATION.peatGenerationSpeed;
 
     public PeatBlock() {
         super(Material.GROUND);
@@ -47,7 +49,7 @@ public class PeatBlock extends Block implements PeatItem {
         }
         if (world.getBiome(pos) instanceof BiomeSwamp) {
             for (int i = 0; i < 4; ++i) {
-                BlockPos blockpos = pos.add(rand.nextInt(9) - 1, rand.nextInt(10) - 3, rand.nextInt(9) - 1);
+                BlockPos blockpos = pos.add(rand.nextInt(peatGenerationSpeed + 1), rand.nextInt(peatGenerationSpeed + 1), rand.nextInt(peatGenerationSpeed + 1));
 
                 if (blockpos.getY() >= 0 && blockpos.getY() < 256 && !world.isBlockLoaded(blockpos)) {
                     return;

--- a/src/main/java/org/jurassicraft/server/block/PeatBlock.java
+++ b/src/main/java/org/jurassicraft/server/block/PeatBlock.java
@@ -1,6 +1,7 @@
 package org.jurassicraft.server.block;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDirt;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyInteger;
@@ -43,6 +44,27 @@ public class PeatBlock extends Block implements PeatItem {
             }
         } else if (moisture < 7) {
             world.setBlockState(pos, state.withProperty(MOISTURE, 7), 2);
+        }
+        if (world.getBiome(pos) instanceof BiomeSwamp) {
+            for (int i = 0; i < 4; ++i) {
+                BlockPos blockpos = pos.add(rand.nextInt(9) - 1, rand.nextInt(10) - 3, rand.nextInt(9) - 1);
+
+                if (blockpos.getY() >= 0 && blockpos.getY() < 256 && !world.isBlockLoaded(blockpos)) {
+                    return;
+                }
+
+                IBlockState iblockstate = world.getBlockState(blockpos.up());
+                IBlockState iblockstate1 = world.getBlockState(blockpos);
+                IBlockState iBlockState2 = world.getBlockState(blockpos.up(2));
+                IBlockState iBlockState3 = world.getBlockState(blockpos.up(3));
+
+
+                if (iblockstate1.getBlock() == Blocks.DIRT && iblockstate1.getValue(BlockDirt.VARIANT) == BlockDirt.DirtType.DIRT) {
+                    if (iblockstate.getBlock() == Blocks.GRASS || iBlockState2.getBlock() == Blocks.GRASS || iBlockState3.getBlock() == Blocks.GRASS) {
+                        world.setBlockState(blockpos, BlockHandler.PEAT.getDefaultState());
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/org/jurassicraft/server/conf/JurassiCraftConfig.java
+++ b/src/main/java/org/jurassicraft/server/conf/JurassiCraftConfig.java
@@ -72,6 +72,9 @@ public class JurassiCraftConfig { //TODO: move all structures to same parent pac
 
         @Config.Name("Petrified Tree Generation")
         public boolean petrifiedTreeGeneration = true;
+
+        @Config.Name("Peat Spread Speed")
+        public int peatSpreadSpeed = 1;
     }
 
     public static class PlantGeneration {
@@ -86,6 +89,10 @@ public class JurassiCraftConfig { //TODO: move all structures to same parent pac
 
         @Config.Name("Gracilaria Generation")
         public boolean gracilariaGeneration = true;
+
+        @Config.Name("Peat Spread Speed")
+        @Config.Comment("Lower is faster, Higher is slower!")
+        public int peatGenerationSpeed = 20;
     }
 
     public static class StructureGeneration {

--- a/src/main/java/org/jurassicraft/server/conf/JurassiCraftConfig.java
+++ b/src/main/java/org/jurassicraft/server/conf/JurassiCraftConfig.java
@@ -72,9 +72,6 @@ public class JurassiCraftConfig { //TODO: move all structures to same parent pac
 
         @Config.Name("Petrified Tree Generation")
         public boolean petrifiedTreeGeneration = true;
-
-        @Config.Name("Peat Spread Speed")
-        public int peatSpreadSpeed = 1;
     }
 
     public static class PlantGeneration {

--- a/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
+++ b/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
@@ -76,7 +76,7 @@ public class ServerEventHandler {
 
     @SubscribeEvent
     public static void tickEvent(TickEvent.WorldTickEvent event) {
-        if (event.world.getTotalWorldTime() % 25 == 0) {
+        if (event.world.getTotalWorldTime() % 20 == 0) {
             WorldServer world = event.world.getMinecraftServer().getWorld(0);
             Chunk[] chunklist = world.getChunkProvider().getLoadedChunks().toArray(new Chunk[0]);
             int randomChunk = ThreadLocalRandom.current().nextInt(0, chunklist.length);
@@ -84,13 +84,14 @@ public class ServerEventHandler {
             Random random = new Random();
             int zeroX = chunklist[randomChunk].getPos().getXStart() + random.nextInt(16);
             int zeroZ = chunklist[randomChunk].getPos().getZStart() + random.nextInt(16);
+            BlockPos.MutableBlockPos mutualBlockPos;
 
-            if(!(world.getBiomeForCoordsBody(new BlockPos(zeroX, 0, zeroZ)) instanceof BiomeSwamp))
+            if(!(world.getBiomeForCoordsBody(mutualBlockPos = new BlockPos.MutableBlockPos(zeroX, 0, zeroZ)) instanceof BiomeSwamp))
                 return;
 
             for (int i = 255; i > -1; i--) {
-                if (world.getBlockState(new BlockPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(new BlockPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
-                    world.setBlockState(new BlockPos(zeroX, i, zeroZ), BlockHandler.PEAT.getDefaultState());
+                if (world.getBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(new BlockPos.MutableBlockPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
+                    world.setBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ), BlockHandler.PEAT.getDefaultState());
                     break;
                 }
             }

--- a/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
+++ b/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
@@ -90,7 +90,7 @@ public class ServerEventHandler {
                 return;
 
             for (int i = 255; i > -1; i--) {
-                if (world.getBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(new BlockPos.MutableBlockPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
+                if (world.getBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(mutualBlockPos.setPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
                     world.setBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ), BlockHandler.PEAT.getDefaultState());
                     break;
                 }

--- a/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
+++ b/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
@@ -1,6 +1,8 @@
 package org.jurassicraft.server.event;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDirt;
+import net.minecraft.block.BlockGrass;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.EntityVillager;
@@ -15,8 +17,11 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeDecorator;
+import net.minecraft.world.biome.BiomeSwamp;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraftforge.common.BiomeDictionary;
@@ -30,6 +35,7 @@ import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
 import org.jurassicraft.JurassiCraft;
 import org.jurassicraft.server.block.BlockHandler;
 import org.jurassicraft.server.block.FossilizedTrackwayBlock;
@@ -48,6 +54,7 @@ import org.jurassicraft.server.world.loot.Loot;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class ServerEventHandler {
 	
@@ -66,7 +73,30 @@ public class ServerEventHandler {
     public static void onWorldLoad(final WorldEvent.Load event) {
         GameRuleHandler.register(event.getWorld());
     }
-    
+
+    @SubscribeEvent
+    public static void tickEvent(TickEvent.WorldTickEvent event) {
+        if (event.world.getTotalWorldTime() % 25 == 0) {
+            WorldServer world = event.world.getMinecraftServer().getWorld(0);
+            Chunk[] chunklist = world.getChunkProvider().getLoadedChunks().toArray(new Chunk[0]);
+            int randomChunk = ThreadLocalRandom.current().nextInt(0, chunklist.length);
+
+            Random random = new Random();
+            int zeroX = chunklist[randomChunk].getPos().getXStart() + random.nextInt(16);
+            int zeroZ = chunklist[randomChunk].getPos().getZStart() + random.nextInt(16);
+
+            if(!(world.getBiomeForCoordsBody(new BlockPos(zeroX, 0, zeroZ)) instanceof BiomeSwamp))
+                return;
+
+            for (int i = 255; i > -1; i--) {
+                if (world.getBlockState(new BlockPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(new BlockPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
+                    world.setBlockState(new BlockPos(zeroX, i, zeroZ), BlockHandler.PEAT.getDefaultState());
+                    break;
+                }
+            }
+        }
+    }
+
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void blockRegistry(final RegistryEvent.Register<Block> e) {
     	e.getRegistry().register(BlockHandler.VINES.setRegistryName("minecraft", "vine"));

--- a/src/main/java/org/jurassicraft/server/food/FoodHelper.java
+++ b/src/main/java/org/jurassicraft/server/food/FoodHelper.java
@@ -52,6 +52,7 @@ public class FoodHelper {
         registerFood(Blocks.DOUBLE_PLANT, FoodType.PLANT, 2000);
         registerFood(Blocks.BROWN_MUSHROOM, FoodType.PLANT, 250);
         registerFood(Blocks.RED_MUSHROOM, FoodType.PLANT, 250);
+        registerFood(Blocks.BEETROOTS, FoodType.PLANT, 2000);
 
         registerFood(ItemHandler.COCKROACHES, FoodType.INSECT, 250);
         registerFood(ItemHandler.CRICKETS, FoodType.INSECT, 250);
@@ -76,6 +77,8 @@ public class FoodHelper {
         }
 
         registerFood(Items.WHEAT, FoodType.PLANT, 1000);
+        registerFood(Items.BEETROOT, FoodType.PLANT, 1000);
+        registerFood(Items.BEETROOT_SEEDS, FoodType.PLANT, 100);
         registerFood(Items.WHEAT_SEEDS, FoodType.PLANT, 100);
         registerFood(Items.MELON_SEEDS, FoodType.PLANT, 100);
         registerFood(Items.PUMPKIN_SEEDS, FoodType.PLANT, 100);


### PR DESCRIPTION
Renewable Peat:
Grass blocks in Swamp biomes is converted into Peat.
-Only converts up to 3 Dirt blocks below the Grass Block
-Only does this within a Swamp biome (cannot be done in River or other biomes)